### PR TITLE
Fix: Use `store` action of `--out` argument

### DIFF
--- a/vtscan.py
+++ b/vtscan.py
@@ -26,7 +26,7 @@ def arguments():
                         action="store", default=api_key, help="Specify VT API key")
     parser.add_argument("-q", "--quiet", dest="QUIET", action="store_true", help="Do not print vendor analysis results")
     parser.add_argument("-p", "--positive", dest="POSITIVE", action="store_true", help="Show only positive results in vendor analysis")
-    parser.add_argument("-o", "--out", dest="OUT", action="store_true", help="Save JSON response to a file")
+    parser.add_argument("-o", "--out", dest="OUT", metavar="<file>", action="store", help="Save JSON response to a file")
     parser.add_argument("-c", "--clear", dest="CLEAR", action="store_true", help="Clear screen before printing vendor analysis results ")
     res = parser.parse_args()
     return res


### PR DESCRIPTION
Fixes #7.

The argument was not being saved for some reason. I'm not very familiar with the argparse library, but changing the action fixed the issue.